### PR TITLE
optimises riggeometry.cpp

### DIFF
--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -117,7 +117,7 @@ bool RigGeometry::initFromParentSkeleton(osg::NodeVisitor* nv)
     for (osg::NodePath::const_reverse_iterator it = path.rbegin()+1; it != path.rend(); ++it)
     {
         osg::Node* node = *it;
-        if (!node->asTransform())
+        if (node->asTransform())
             continue;
         if (Skeleton* skel = dynamic_cast<Skeleton*>(node))
         {

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -3,6 +3,7 @@
 #include <osg/Version>
 
 #include <components/debug/debuglog.hpp>
+#include <osg/MatrixTransform>
 
 #include "skeleton.hpp"
 #include "util.hpp"

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -313,7 +313,8 @@ void RigGeometry::updateGeomToSkelMatrix(const osg::NodePath& nodePath)
 {
     bool foundSkel = false;
     osg::RefMatrix* geomToSkelMatrix = mGeomToSkelMatrix;
-    if (geomToSkelMatrix) geomToSkelMatrix->makeIdentity();
+    if (geomToSkelMatrix)
+        geomToSkelMatrix->makeIdentity();
     for (osg::NodePath::const_iterator it = nodePath.begin(); it != nodePath.end()-1; ++it)
     {
         osg::Node* node = *it;
@@ -329,7 +330,8 @@ void RigGeometry::updateGeomToSkelMatrix(const osg::NodePath& nodePath)
                 osg::MatrixTransform* matrixTrans = trans->asMatrixTransform();
                 if (matrixTrans && matrixTrans->getMatrix().isIdentity())
                     continue;
-                if (!geomToSkelMatrix) geomToSkelMatrix = mGeomToSkelMatrix = new osg::RefMatrix;
+                if (!geomToSkelMatrix)
+                    geomToSkelMatrix = mGeomToSkelMatrix = new osg::RefMatrix;
                 trans->computeWorldToLocalMatrix(*geomToSkelMatrix, nullptr);
             }
         }

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -313,6 +313,7 @@ void RigGeometry::updateGeomToSkelMatrix(const osg::NodePath& nodePath)
 {
     bool foundSkel = false;
     osg::RefMatrix* geomToSkelMatrix = mGeomToSkelMatrix;
+    if (geomToSkelMatrix) geomToSkelMatrix->makeIdentity();
     for (osg::NodePath::const_iterator it = nodePath.begin(); it != nodePath.end()-1; ++it)
     {
         osg::Node* node = *it;

--- a/components/sceneutil/riggeometry.cpp
+++ b/components/sceneutil/riggeometry.cpp
@@ -330,8 +330,7 @@ void RigGeometry::updateGeomToSkelMatrix(const osg::NodePath& nodePath)
                 if (matrixTrans && matrixTrans->getMatrix().isIdentity())
                     continue;
                 if (!geomToSkelMatrix) geomToSkelMatrix = mGeomToSkelMatrix = new osg::RefMatrix;
-                if (matrixTrans) geomToSkelMatrix->preMult(matrixTrans->getMatrix());
-                else trans->computeWorldToLocalMatrix(*geomToSkelMatrix, nullptr);
+                trans->computeWorldToLocalMatrix(*geomToSkelMatrix, nullptr);
             }
         }
     }


### PR DESCRIPTION
1. We skip `this` during node path iterations. `this` is not a node we are interested in.
2. We avoid allocating a new `mGeomToSkelMatrix` per frame and avoid a `ref_ptr` associated with its update.
3. We speed up a search for the `Skeleton` node by adding a `continue;` condition prior to an expensive `dynamic_cast`.