### PR TITLE
fixes LightSource logic errors

### DIFF
--- a/apps/openmw/mwrender/animation.cpp
+++ b/apps/openmw/mwrender/animation.cpp
@@ -389,11 +389,6 @@ namespace MWRender
             mAlpha = alpha;
         }
 
-        void setLightSource(const osg::ref_ptr<SceneUtil::LightSource>& lightSource)
-        {
-            mLightSource = lightSource;
-        }
-
     protected:
         void setDefaults(osg::StateSet* stateset) override
         {
@@ -416,13 +411,10 @@ namespace MWRender
         {
             osg::Material* material = static_cast<osg::Material*>(stateset->getAttribute(osg::StateAttribute::MATERIAL));
             material->setAlpha(osg::Material::FRONT_AND_BACK, mAlpha);
-            if (mLightSource)
-                mLightSource->setActorFade(mAlpha);
         }
 
     private:
         float mAlpha;
-        osg::ref_ptr<SceneUtil::LightSource> mLightSource;
     };
 
     struct Animation::AnimSource
@@ -1484,6 +1476,7 @@ namespace MWRender
         bool exterior = mPtr.isInCell() && mPtr.getCell()->getCell()->isExterior();
 
         mExtraLightSource = SceneUtil::addLight(parent, esmLight, Mask_ParticleSystem, Mask_Lighting, exterior);
+        mExtraLightSource->setActorFade(mAlpha);
     }
 
     void Animation::addEffect (const std::string& model, int effectId, bool loop, const std::string& bonename, const std::string& texture)
@@ -1639,7 +1632,6 @@ namespace MWRender
             if (mTransparencyUpdater == nullptr)
             {
                 mTransparencyUpdater = new TransparencyUpdater(alpha);
-                mTransparencyUpdater->setLightSource(mExtraLightSource);
                 mObjectRoot->addCullCallback(mTransparencyUpdater);
             }
             else
@@ -1650,6 +1642,8 @@ namespace MWRender
             mObjectRoot->removeCullCallback(mTransparencyUpdater);
             mTransparencyUpdater = nullptr;
         }
+        if (mExtraLightSource)
+            mExtraLightSource->setActorFade(alpha);
     }
 
     void Animation::setLightEffect(float effect)


### PR DESCRIPTION
We currently update `LightSource::setActorFade` in `TransparencyUpdater`. There are several logic errors inherent in this approach:
1. We fail to update `LightSource::setActorFade` for off screen actors because their `TransparencyUpdater` cull callback is not invoked.
2. We fail to update `LightSource::setActorFade` in the instant that a `TransparencyUpdater` is removed.
3. We fail to update `LightSource::setActorFade` when an `mExtraLightSource` is created after calling `Animation::setAlpha`.
With this PR we avoid such issues by updating `LightSource::setActorFade` in `Animation::setAlpha` and `Animation::addExtraLightSource` instead.